### PR TITLE
Fix color calculation

### DIFF
--- a/YordanApi/Domain/ValueObjects/Tag.cs
+++ b/YordanApi/Domain/ValueObjects/Tag.cs
@@ -4,7 +4,8 @@ public record Tag(string Name) {
     public Color Color {
         get {
             var hash = Name.GetHashCode();
-            return (Color)(hash % (int)Color.Zinc); // Adjust the modulo value as needed
+            var colorsCount = Enum.GetValues<Color>().Length;
+            return (Color)(Math.Abs(hash) % colorsCount);
         }
     }
 };


### PR DESCRIPTION
## Summary
- fix Tag color calculation when using a negative hash or the wrong modulo

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685818e8d4f4832ebc5c6e55963a56e4