### PR TITLE
Refactor frontend components and fix composables

### DIFF
--- a/client/components/languages/AddLanguageModal.vue
+++ b/client/components/languages/AddLanguageModal.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+const props = defineProps<{
+  modelValue: boolean
+  createLanguage: (language: { name: string; autoName?: string; autoNameTranscription?: string; isPublished: boolean }) => Promise<boolean> | boolean
+}>()
+const emit = defineEmits(['update:modelValue','created'])
+
+const schema = z.object({
+  name: z.string().nonempty('Название языка не может быть пустым'),
+  autoName: z.string().optional(),
+  autoNameTranscription: z.string().optional(),
+  isPublished: z.boolean().default(false),
+})
+
+type Schema = z.output<typeof schema>
+
+const state = reactive<Schema>({
+  name: '',
+  autoName: '',
+  autoNameTranscription: '',
+  isPublished: false,
+})
+
+async function onSubmit(event: FormSubmitEvent<Schema>) {
+  await props.createLanguage(event.data)
+  emit('created')
+  emit('update:modelValue', false)
+  state.name = ''
+  state.autoName = ''
+  state.autoNameTranscription = ''
+  state.isPublished = false
+}
+</script>
+
+<template>
+  <UModal :model-value="modelValue" @update:model-value="emit('update:modelValue', $event)" title="Создать язык">
+    <template #body>
+      <UCard>
+        <UForm :state="state" :schema="schema" @submit="onSubmit">
+          <div class="flex flex-col gap-2 w-full">
+            <UFormField name="name" label="Название языка (понятное)" required>
+              <UInput v-model="state.name" class="w-full" />
+            </UFormField>
+            <UFormField name="autoName" label="Самоназвание языка">
+              <UInput v-model="state.autoName" class="w-full" />
+            </UFormField>
+            <UFormField name="autoNameTranscription" label="Транскрипция самоназвания языка">
+              <UInput v-model="state.autoNameTranscription" class="w-full">
+                <template #trailing>
+                  <XsampaToIpaButton v-model="state.autoNameTranscription" />
+                </template>
+              </UInput>
+            </UFormField>
+            <UFormField name="isPublished">
+              <USwitch v-model="state.isPublished" label="Публично доступен" />
+            </UFormField>
+            <UButton type="submit" variant="soft" color="success" class="w-full justify-center cursor-pointer">Добавить</UButton>
+          </div>
+        </UForm>
+      </UCard>
+    </template>
+  </UModal>
+</template>
+
+<style scoped>
+</style>

--- a/client/components/languages/LanguageCard.vue
+++ b/client/components/languages/LanguageCard.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import type { Language } from '~/composables/useLanguages'
+
+const props = defineProps<{ language: Language }>()
+</script>
+
+<template>
+  <UCard variant="soft">
+    <template #header>
+      <UButton variant="link" :to="`/languages/${props.language.id}`" class="text-neutral hover:text-primary">
+        <h5 class="text-lg">{{ props.language.name }} — {{ props.language.autoName }} /{{ props.language.autoNameTranscription }}/</h5>
+      </UButton>
+    </template>
+    {{ props.language.description }}
+  </UCard>
+</template>
+
+<style scoped></style>

--- a/client/composables/useLanguages.ts
+++ b/client/composables/useLanguages.ts
@@ -15,18 +15,19 @@ export const useLanguages = () => {
         credentials: 'include',
     })
 
-    function createLanguage(language: { name: string, autoName?: string, autoNameTranscription?: string, isPublished: boolean }) {
-        const res = useFetch('/api/v1/languages', {
+    async function createLanguage(language: { name: string, autoName?: string, autoNameTranscription?: string, isPublished: boolean }) {
+        const { error } = await useFetch('/api/v1/languages', {
             method: 'POST',
             body: JSON.stringify(language),
             watch: false,
             headers: { 'Content-Type': 'application/json'  },
             credentials: 'include',
         })
-        if (!res.error.value) {
-            setTimeout(refresh, 1000)
+        if (!error.value) {
+            await refresh()
+            return true
         }
-        return res
+        return false
     }
 
     return { data, error, pending, createLanguage, refreshLanguages: refresh }

--- a/client/pages/login.vue
+++ b/client/pages/login.vue
@@ -2,6 +2,8 @@
 import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
+const { login } = useAuth()
+
 const schema = z.object({
     userName: z.string({ message: '' }),
     password: z.string({ message: '' }).min(8, 'Минимум 8 символов'),
@@ -16,32 +18,15 @@ const state = reactive<Partial<Schema>>({
 
 const formError = ref<string|null>(null)
 
-async function login(username: string, password: string): Promise<boolean> {
-    const { error } = await useFetch('/api/v1/login', {
-        method: 'POST',
-        body: JSON.stringify({ username, password }),
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        watch: false,
-    })
-    if (error.value) {
-        formError.value = "Неправильный логин или пароль"
-        setTimeout(() => {
-            formError.value = null
-        }, 5000)
-        return false
-    }
-    formError.value = null;
-
-    const { fetchUser } = useAuth()
-    await fetchUser()
-
-    return true
-}
 
 async function onSubmit(event: FormSubmitEvent<Schema>) {
     if (await login(event.data.userName, event.data.password)) {
         await useRouter().push('/')
+    } else {
+        formError.value = 'Неправильный логин или пароль'
+        setTimeout(() => {
+            formError.value = null
+        }, 5000)
     }
 }
 


### PR DESCRIPTION
## Summary
- add reusable AddLanguageModal and LanguageCard components
- use new components on languages index page
- optimize createLanguage function in composable
- expose login and register functions from useAuth and fix logic
- update login page to use composable

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `npx eslint .` *(fails: cannot find `.nuxt` config)*

------
https://chatgpt.com/codex/tasks/task_e_68581b55f6d4832e8bb06991ed6bf826