### PR TITLE
Fix language interface editorsIds

### DIFF
--- a/client/composables/useLanguages.ts
+++ b/client/composables/useLanguages.ts
@@ -1,7 +1,7 @@
 export interface Language {
     id: string,
     authorId: string,
-    editorsId: string[],
+    editorsIds: string[],
     name: string,
     autoName: string,
     autoNameTranscription: string,


### PR DESCRIPTION
## Summary
- rename `editorsId` to `editorsIds` in the language composable interface

## Testing
- `npm install` *(fails to fully build due to missing fonts)*
- `npm run build` *(fails: could not initialize font providers)*

------
https://chatgpt.com/codex/tasks/task_e_68581ab0e158832ea8accfa0d5ea03bc